### PR TITLE
 #163614443 staff can cancel claim

### DIFF
--- a/src/application/IntrinsicMiddlewares/IntrinsicMiddlewares.js
+++ b/src/application/IntrinsicMiddlewares/IntrinsicMiddlewares.js
@@ -1,0 +1,21 @@
+import services from '../services';
+
+const { ClaimService, StaffService } = services;
+
+class IntrinsicMiddlewares {
+  static async claimMiddleware(tenant, staffId, claimId) {
+    const claim = await ClaimService.findClaimByPk(tenant, claimId);
+    if (!claim) return [404, 'Claim does not exist.'];
+
+    const staff = await StaffService.findStaffByStaffId(tenant, staffId);
+    if (claim.requester !== staff.id) return [401, 'You do not have access to this claim.'];
+
+    const statuses = ['Awaiting BSM', 'Awaiting supervisor'];
+    if (!statuses.includes(claim.status)) {
+      return [403, 'You cannot cancel a claim that is being processed.'];
+    }
+    return [200, 'okay'];
+  }
+}
+
+export default IntrinsicMiddlewares;

--- a/src/application/IntrinsicMiddlewares/index.js
+++ b/src/application/IntrinsicMiddlewares/index.js
@@ -1,0 +1,3 @@
+import IntrinsicMiddlewares from './IntrinsicMiddlewares';
+
+export default IntrinsicMiddlewares;

--- a/src/application/database/migrations/20190118185900-create-claims.js
+++ b/src/application/database/migrations/20190118185900-create-claims.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     status: {
       type: Sequelize.ENUM(
-        'Awaiting supervisor', 'Awaiting BSM', 'Declined', 'Processing', 'Completed'
+        'Awaiting supervisor', 'Awaiting BSM', 'Declined', 'Cancelled', 'Processing', 'Completed'
       ),
       allowNull: false
     },

--- a/src/application/database/models/claims.js
+++ b/src/application/database/models/claims.js
@@ -18,7 +18,7 @@ const claims = (sequelize, DataTypes) => {
     },
     status: {
       type: DataTypes.ENUM(
-        'Awaiting supervisor', 'Awaiting BSM', 'Declined', 'Processing', 'Completed'
+        'Awaiting supervisor', 'Awaiting BSM', 'Declined', 'Cancelled', 'Processing', 'Completed'
       ),
       allowNull: false
     }

--- a/src/application/database/seeders/20181230213538-demo-staff.js
+++ b/src/application/database/seeders/20181230213538-demo-staff.js
@@ -90,6 +90,36 @@ module.exports = {
     role: 2,
     createdAt: '2018-12-30',
     updatedAt: '2018-12-30'
+  },
+  {
+    staffId: 'TN074695',
+    firstname: 'Archnic',
+    lastname: 'Zintra',
+    middleName: 'Zulch',
+    email: 'zintra.zulch@init.com',
+    password: bcrypt.hashSync('password', 7),
+    image: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1536757459/dummy-profile.png',
+    branchId: 1,
+    supervisorId: 1,
+    bsmId: 3,
+    role: 4,
+    createdAt: '2019-03-03',
+    updatedAt: '2019-03-03'
+  },
+  {
+    staffId: 'TN075595',
+    firstname: 'Blizcan',
+    lastname: 'Ablick',
+    middleName: 'Pitz',
+    email: 'ablick.pitz@init.com',
+    password: bcrypt.hashSync('password', 7),
+    image: 'https://res.cloudinary.com/dbsxxymfz/image/upload/v1536757459/dummy-profile.png',
+    branchId: 1,
+    supervisorId: 1,
+    bsmId: 3,
+    role: 3,
+    createdAt: '2019-03-03',
+    updatedAt: '2019-03-03'
   }]),
   down: queryInterface => queryInterface.bulkDelete('Staff')
 };

--- a/src/application/database/seeders/20190204213538-demo-claim.js
+++ b/src/application/database/seeders/20190204213538-demo-claim.js
@@ -58,6 +58,26 @@ module.exports = {
     status: 'Awaiting supervisor',
     createdAt: '2019-02-26',
     updatedAt: '2019-02-26'
+  },
+  {
+    monthOfClaim: 'Jan, 2019',
+    weekday: 9,
+    weekend: 2,
+    shift: null,
+    requester: 7,
+    status: 'Awaiting supervisor',
+    createdAt: '2019-03-03',
+    updatedAt: '2019-03-03'
+  },
+  {
+    monthOfClaim: 'Jan, 2019',
+    weekday: 16,
+    weekend: 5,
+    shift: null,
+    requester: 8,
+    status: 'Processing',
+    createdAt: '2019-03-03',
+    updatedAt: '2019-03-03'
   }]),
   down: queryInterface => queryInterface.bulkDelete('Claims')
 };

--- a/src/application/features/Claim/Claim.js
+++ b/src/application/features/Claim/Claim.js
@@ -2,6 +2,7 @@ import helpers from '../../helpers';
 import services from '../../services';
 import notifications from '../../notifications';
 import { eventNames } from '../../utils/types';
+import IntrinsicMiddlewares from '../../IntrinsicMiddlewares';
 
 const { ClaimService, StaffService } = services;
 const { ClaimHelpers } = helpers;
@@ -70,6 +71,16 @@ class Claim {
 
   static decline(req) {
     return Claim.runClaimApproval(req, 'decline');
+  }
+
+  static async cancel(req) {
+    const { tenant, currentStaff: { staffId }, params: { claimId } } = req;
+    const [statusCode, message] = await IntrinsicMiddlewares.claimMiddleware(
+      tenant, staffId, claimId
+    );
+    if (statusCode !== 200) return [statusCode, message];
+    const [updated, claim] = await ClaimService.cancelClaim(tenant, claimId);
+    return [200, `Claim${updated ? '' : ' not'} cancelled.`, claim[0]];
   }
 }
 

--- a/src/application/features/Claim/__tests__/claim.spec.js
+++ b/src/application/features/Claim/__tests__/claim.spec.js
@@ -1,6 +1,8 @@
 import Claim from '../Claim';
 import ClaimService from '../../../services/ClaimService';
 import { mockReq } from '../../../../__tests__/__mocks__';
+import IntrinsicMiddlewares from '../../../IntrinsicMiddlewares';
+
 
 describe('Claim Unit Test', () => {
   describe('runClaimApproval', () => {
@@ -13,6 +15,19 @@ describe('Claim Unit Test', () => {
       expect(result).toHaveLength(3);
       expect(result[0]).toEqual(200);
       expect(result[1]).toEqual('Claim not approved.');
+    });
+  });
+
+  describe('cancelClaim', () => {
+    it('should send a non-approval message if approval was not updated on the DB.', async () => {
+      jest.spyOn(IntrinsicMiddlewares, 'claimMiddleware').mockResolvedValue([200, 'okay']);
+      jest.spyOn(ClaimService, 'cancelClaim').mockResolvedValue([false, {}]);
+
+      const result = await Claim.cancel(mockReq);
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual(200);
+      expect(result[1]).toEqual('Claim not cancelled.');
     });
   });
 });

--- a/src/application/features/PasswordReset/__tests__/passwordResetTests.spec.js
+++ b/src/application/features/PasswordReset/__tests__/passwordResetTests.spec.js
@@ -2,10 +2,8 @@ import PasswordReset from '../index';
 import PasswordResetHelper from '../../../helpers/PasswordResetHelper';
 import { mockReq } from '../../../../__tests__/__mocks__';
 import krypter from '../../../helpers/krypter';
-import tenantsModels from '../../../database/tenantsModels';
 import services from '../../../services';
 
-const { Staff } = tenantsModels.INIT;
 const { StaffService } = services;
 
 jest.mock('../../../helpers/Mailer');
@@ -19,7 +17,7 @@ describe('PasswordReset', () => {
 
   describe('Forgot password', () => {
     it('should fail if staff does not exist', async () => {
-      jest.spyOn(Staff, 'findOne').mockResolvedValue(null);
+      jest.spyOn(StaffService, 'findStaffByStaffId').mockResolvedValue(null);
 
       const [statusCode, message] = await PasswordReset
         .forgotPassword(mockReq);

--- a/src/application/services/BasicQuerier/BasicQuerier.js
+++ b/src/application/services/BasicQuerier/BasicQuerier.js
@@ -1,0 +1,16 @@
+import tenantsModels from '../../database/tenantsModels';
+
+class BasicQuerier {
+  static findByPk(tenant, model, pk) {
+    return tenantsModels[tenant][model].findByPk(pk, { raw: true });
+  }
+
+  static passwordResetQueries(tenant, method, staffId, data) {
+    let options = { where: { staffId }, raw: true };
+    if (method === 'destroy') options.returning = true;
+    if (data) options = data;
+    return tenantsModels[tenant].PasswordResetRequest[method](options);
+  }
+}
+
+export default BasicQuerier;

--- a/src/application/services/BasicQuerier/index.js
+++ b/src/application/services/BasicQuerier/index.js
@@ -1,0 +1,3 @@
+import BasicQuerier from './BasicQuerier';
+
+export default BasicQuerier;

--- a/src/application/services/BranchService/BranchService.js
+++ b/src/application/services/BranchService/BranchService.js
@@ -1,9 +1,8 @@
-import tenantsModels from '../../database/tenantsModels';
+import BasicQuerier from '../BasicQuerier';
 
 class BranchService {
   static fetchBranchByPk(tenant, branchId) {
-    const { Branch } = tenantsModels[tenant];
-    return Branch.findByPk(branchId, { raw: true });
+    return BasicQuerier.findByPk(tenant, 'Branch', branchId);
   }
 }
 

--- a/src/application/services/ClaimService/ClaimService.js
+++ b/src/application/services/ClaimService/ClaimService.js
@@ -1,6 +1,7 @@
 import tenantsModels from '../../database/tenantsModels';
 import ClaimApprovalHistoryService from '../ClaimApprovalHistoryService';
 import GenericHelpers from '../../helpers/GenericHelpers';
+import BasicQuerier from '../BasicQuerier';
 
 class ClaimService {
   static findOrCreateClaim(tenant, overtimeRequest) {
@@ -14,6 +15,10 @@ class ClaimService {
       defaults: overtimeRequest,
       raw: true
     });
+  }
+
+  static findClaimByPk(tenant, claimId) {
+    return BasicQuerier.findByPk(tenant, 'Claims', claimId);
   }
 
   static updateClaim(tenant, updatePayload, claimId) {
@@ -51,6 +56,11 @@ class ClaimService {
 
   static declineClaim(tenant, lineManager, claimId) {
     return ClaimService.runClaimApproval(tenant, lineManager, claimId, 'decline');
+  }
+
+  static cancelClaim(tenant, claimId) {
+    const updatePayload = { status: 'Cancelled' };
+    return ClaimService.updateClaim(tenant, updatePayload, claimId);
   }
 }
 

--- a/src/application/services/PasswordResetService/PasswordResetService.js
+++ b/src/application/services/PasswordResetService/PasswordResetService.js
@@ -1,19 +1,17 @@
 import tenantsModels from '../../database/tenantsModels';
+import BasicQuerier from '../BasicQuerier';
 
 class PasswordResetService {
   static fetchPasswordResetRequest(tenant, staffId) {
-    const { PasswordResetRequest } = tenantsModels[tenant];
-    return PasswordResetRequest.findOne({ where: { staffId }, raw: true });
+    return BasicQuerier.passwordResetQueries(tenant, 'findOne', staffId);
   }
 
   static deletePasswordResetRequest(tenant, staffId) {
-    const { PasswordResetRequest } = tenantsModels[tenant];
-    return PasswordResetRequest.destroy({ where: { staffId }, returning: true });
+    return BasicQuerier.passwordResetQueries(tenant, 'destroy', staffId);
   }
 
   static updateOrInsertResetRequest(tenant, data) {
-    const { PasswordResetRequest } = tenantsModels[tenant];
-    return PasswordResetRequest.upsert(data);
+    return BasicQuerier.passwordResetQueries(tenant, 'upsert', undefined, data);
   }
 }
 

--- a/src/tenants/init/__tests__/init.claims.approval.spec.js
+++ b/src/tenants/init/__tests__/init.claims.approval.spec.js
@@ -20,17 +20,13 @@ describe('Claim Approval Tests', () => {
     server.close(done);
   });
 
-  describe('Approve Claim', () => {
+  describe('Supervisor Claim Approval', () => {
     let supervisorToken;
-    let bsmToken;
 
     beforeAll(async () => {
       // verify line manager
       const supervisorVerificationResponse = await request.get(`/verify?hash=${supervisorHash}`);
       supervisorToken = supervisorVerificationResponse.header['set-cookie'];
-
-      const bsmVerificationResponse = await request.get(`/verify?hash=${bsmHash}`);
-      bsmToken = bsmVerificationResponse.header['set-cookie'];
     });
 
     afterEach(() => {
@@ -53,7 +49,7 @@ describe('Claim Approval Tests', () => {
     });
   });
 
-  describe('Decline Claim', () => {
+  describe('BSM Claim Approval', () => {
     let bsmToken;
 
     beforeAll(async () => {
@@ -66,19 +62,72 @@ describe('Claim Approval Tests', () => {
       jest.clearAllMocks();
     });
 
-    it('should approve claim (BSM).', async () => {
+    it('should approve claim.', async () => {
       const response = await request.get('/line-manager/claims/pending/1/approve').set('cookie', bsmToken);
       expect(response.status).toBe(200);
       expect(response.body.message).toEqual('Claim approved.');
       expect(response.body.data.status).toEqual('Processing');
     });
 
-    it('should decline claim (BSM).', async () => {
+    it('should decline claim.', async () => {
       const response = await request.get('/line-manager/claims/pending/2/decline').set('cookie', bsmToken);
 
       expect(response.status).toBe(200);
       expect(response.body.message).toEqual('Claim declined.');
       expect(response.body.data.status).toEqual('Declined');
+    });
+  });
+
+  describe('Staff Claim Approval (Cancelled)', () => {
+    let staffToken;
+    let staffToken2;
+
+    beforeAll(async () => {
+      // signin a user
+      const response = await request
+        .post('/signin')
+        .send({ staffId: 'TN074695', password: 'password' })
+        .set('Accept', 'application/json');
+
+      staffToken = response.header['set-cookie'];
+
+      // signin a user
+      const response2 = await request
+        .post('/signin')
+        .send({ staffId: 'TN075595', password: 'password' })
+        .set('Accept', 'application/json');
+
+      staffToken2 = response2.header['set-cookie'];
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it('should fail if claim does not exist.', async () => {
+      const response = await request.delete('/users/claims/10000').set('cookie', staffToken2);
+      expect(response.status).toBe(404);
+      expect(response.body.message).toEqual('Claim does not exist.');
+    });
+
+    it('should fail if staff is unauthorised to access claim.', async () => {
+      const response = await request.delete('/users/claims/7').set('cookie', staffToken2);
+      expect(response.status).toBe(401);
+      expect(response.body.message).toEqual('You do not have access to this claim.');
+    });
+
+    it('should cancel claim.', async () => {
+      const response = await request.delete('/users/claims/7').set('cookie', staffToken);
+      expect(response.status).toBe(200);
+      expect(response.body.message).toEqual('Claim cancelled.');
+      expect(response.body.data.status).toEqual('Cancelled');
+    });
+
+    it('Cancelling a claim in the processing stage should fail.', async () => {
+      const response = await request.delete('/users/claims/8').set('cookie', staffToken2);
+      expect(response.status).toBe(403);
+      expect(response.body.message).toEqual('You cannot cancel a claim that is being processed.');
     });
   });
 });

--- a/src/tenants/init/__tests__/init.createOvertimeClaim.spec.js
+++ b/src/tenants/init/__tests__/init.createOvertimeClaim.spec.js
@@ -51,7 +51,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if request contains unexpected props or is an empty request', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekend: 4 });
@@ -63,7 +63,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if maximum number of shift days has been exceeded.', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ shift: 25 });
@@ -89,7 +89,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if request is empty', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({});
@@ -101,7 +101,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if request contains props different from weekday, weekend and atm', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekday: 19, shift: 18 });
@@ -113,7 +113,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if weekend and atm are in the same request', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekend: 8, atm: 9 });
@@ -127,7 +127,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if props do not have values', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekend: '' });
@@ -141,7 +141,7 @@ describe('Create Claim Tests', () => {
 
     it('should fail if the value of overtime props exceeds the maximum for the month', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekday: 25, weekend: 14 });
@@ -155,7 +155,7 @@ describe('Create Claim Tests', () => {
 
     it('should successfully submit overtime request', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekday: 20, weekend: 8 });
@@ -166,7 +166,7 @@ describe('Create Claim Tests', () => {
 
     it('should send a conflict error if staff already created claim', async () => {
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekday: 20, weekend: 8 });
@@ -184,7 +184,7 @@ describe('Create Claim Tests', () => {
       jest.spyOn(Staff, 'findOne').mockRejectedValue(err);
 
       const response = await request
-        .post('/claim')
+        .post('/users/claim')
         .set('cookie', token)
         .set('Accept', 'application/json')
         .send({ weekday: 20, weekend: 8 });

--- a/src/tenants/init/controller/index.js
+++ b/src/tenants/init/controller/index.js
@@ -55,6 +55,10 @@ class MainController {
   static async declineClaim(req, res) {
     return Responder.respond(req, res, Claim.decline);
   }
+
+  static async cancelClaim(req, res) {
+    return Responder.respond(req, res, Claim.cancel);
+  }
 }
 
 export default MainController;

--- a/src/tenants/init/index.js
+++ b/src/tenants/init/index.js
@@ -7,7 +7,7 @@ const router = express.Router();
 const {
   forgotPassword, signin, authoriseLineManager, changePassword, updateBranch,
   confirmPasswordResetRequest, resetPassword, addOrChangeLineManager, createOvertimeClaim,
-  pendingClaimsForlineManagers, approveClaim, declineClaim
+  pendingClaimsForlineManagers, approveClaim, declineClaim, cancelClaim
 } = controller;
 const {
   checkProps, checkEntries, checkBranchId, checkStaffId, checkOvertimeProps,
@@ -21,12 +21,13 @@ router.get('/verify', verifyLineManager, authoriseLineManager);
 router.post('/forgot-password', checkProps, checkStaffId, forgotPassword);
 router.get('/confirm-reset-request', confirmPasswordResetRequest);
 
-router.post('/claim',
-  authenticateStaff, checkOvertimeProps, checkOvertimeValues, createOvertimeClaim);
-
 router.get('/line-manager/claims/pending', authenticateLineManager, pendingClaimsForlineManagers);
 router.get('/line-manager/claims/pending/:claimId/approve', authenticateLineManager, approveClaim);
 router.get('/line-manager/claims/pending/:claimId/decline', authenticateLineManager, declineClaim);
+
+router.post('/users/claim',
+  authenticateStaff, checkOvertimeProps, checkOvertimeValues, createOvertimeClaim);
+router.delete('/users/claims/:claimId', authenticateStaff, cancelClaim);
 
 router.post('/users/profile/change-password',
   authenticateStaff, checkProps, checkEntries, changePassword);


### PR DESCRIPTION
#### What does this PR do?
Adds functionality that enables a staff to cancel pending claim.

#### Description of Tasks
- Add method for handing cancel claim
- Recreate middleware for handling claim authorisation and existence
- Update claim on cancel request
- Add delete endpoint for cancelling request
- Rename endpoint from  /claim to /users/claim
- Test functionality

#### Pivotal tracker story
#163614443