### PR TITLE
#165385048 track the change of staff initial password

### DIFF
--- a/src/Application/Database/migrations/20181230124052-create-staff.js
+++ b/src/Application/Database/migrations/20181230124052-create-staff.js
@@ -81,6 +81,9 @@ module.exports = {
         as: 'role'
       }
     },
+    changedPassword: {
+      type: Sequelize.BOOLEAN
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/src/Application/Database/models/staff.js
+++ b/src/Application/Database/models/staff.js
@@ -48,6 +48,9 @@ const staff = (sequelize, DataTypes) => {
     role: {
       type: DataTypes.INTEGER,
       allowNull: false
+    },
+    changedPassword: {
+      type: DataTypes.BOOLEAN
     }
   }, { freezeTableName: true });
 

--- a/src/Application/Features/ChangePassword/ChangePassword.js
+++ b/src/Application/Features/ChangePassword/ChangePassword.js
@@ -10,16 +10,18 @@ class ChangePassword {
     const {
       currentStaff: { staffId }, body: { currentPassword, newPassword }, tenantRef
     } = req;
+    const updatePayload = {};
 
     try {
       const staff = await StaffService.findStaffByStaffIdOrEmail(tenantRef, staffId);
       const isCorrect = await ChangePassword
         .currentPasswordIsCorrect(currentPassword, staff.password);
-      if (!isCorrect) {
-        return [401, 'Password is incorrect'];
-      }
+      if (!isCorrect) return [401, 'Password is incorrect'];
 
-      const updated = await StaffService.updateStaffInfo(tenantRef, staffId, 'password', newPassword);
+      if (currentPassword === 'password') updatePayload.changedPassword = true;
+      updatePayload.password = newPassword;
+
+      const updated = await StaffService.updateStaffInfo(tenantRef, staffId, updatePayload);
 
       if (updated) {
         notifications.emit(eventNames.LogEvent, [activityNames.ChangePassword, staffId]);

--- a/src/Application/Features/ChangePassword/__tests__/changePassword.spec.js
+++ b/src/Application/Features/ChangePassword/__tests__/changePassword.spec.js
@@ -20,10 +20,11 @@ describe('ChangePassword Unit test', () => {
 
   it('should return a status of 500 if update fails', async () => {
     jest.spyOn(StaffService, 'findStaffByStaffIdOrEmail').mockResolvedValue('good');
-    jest.spyOn(StaffService, 'findStaffByStaffIdOrEmail').mockResolvedValue(false);
+    jest.spyOn(StaffService, 'updateStaffInfo').mockResolvedValue(false);
     jest.spyOn(ChangePassword, 'currentPasswordIsCorrect').mockReturnValue(true);
+    const mockRequest = { body: { currentPassword: 'passworded' }, currentStaff: {} };
 
-    const [status, message] = await ChangePassword.processPasswordUpdate(mockReq);
+    const [status, message] = await ChangePassword.processPasswordUpdate(mockRequest);
 
     expect(status).toBe(500);
     expect(message).toBe('Password not changed!');

--- a/src/Application/Features/PasswordReset/PasswordReset.js
+++ b/src/Application/Features/PasswordReset/PasswordReset.js
@@ -49,11 +49,9 @@ class PasswordReset {
       const [statusCode, message] = await PasswordResetHelper
         .findAndValidateResetRequest(tenantRef, staffId, hash);
 
-      if (message !== 'valid') {
-        return [statusCode, message];
-      }
+      if (message !== 'valid') return [statusCode, message];
 
-      const updated = await StaffService.updateStaffInfo(tenantRef, staffId, 'password', password);
+      const updated = await StaffService.updateStaffInfo(tenantRef, staffId, { password });
       if (updated) notifications.emit(eventNames.LogActivity, [activityNames.PasswordReset, staffId]);
 
       return [updated ? 200 : 500, `Password reset ${updated ? '' : 'un'}successful!`];

--- a/src/Application/Features/updateBranch/updateBranch.js
+++ b/src/Application/Features/updateBranch/updateBranch.js
@@ -12,7 +12,7 @@ export default async (req) => {
 
     if (!branch) return [404, 'Branch does not exist.'];
 
-    await StaffService.updateStaffInfo(tenantRef, staffId, 'branchId', branchId);
+    await StaffService.updateStaffInfo(tenantRef, staffId, { branchId });
     notifications.emit(eventNames.LogActivity, [activityNames.ChangeBranch, staffId, branch]);
     return [200, 'Branch updated successfully.', branch];
   } catch (e) {

--- a/src/Application/Features/utilities/helpers/GenericHelpers/GenericHelpers.js
+++ b/src/Application/Features/utilities/helpers/GenericHelpers/GenericHelpers.js
@@ -85,13 +85,6 @@ class GenericHelpers {
     return key;
   }
 
-  static staffUpdateQueryOptions(tenantRef, staffId, field, updatePayload) {
-    return {
-      payload: { [field]: updatePayload },
-      queryOptions: { where: { tenantRef, staffId }, returning: true }
-    };
-  }
-
   static fetchPendingClaimsOptions(tenantRef) {
     return {
       where: { tenantRef, ...GenericHelpers.claimStatusFilter('Awaiting') },

--- a/src/Application/Features/utilities/services/StaffService/StaffService.js
+++ b/src/Application/Features/utilities/services/StaffService/StaffService.js
@@ -1,14 +1,11 @@
 import models from '../../../../Database/models';
 import BasicQuerier from '../BasicQuerier';
-import GenericHelpers from '../../helpers/GenericHelpers';
 
 const { Staff } = models;
 
 class StaffService {
-  static async updateStaffInfo(tenantRef, staffId, field, payloadToUpdate) {
-    const { payload, queryOptions } = GenericHelpers.staffUpdateQueryOptions(
-      tenantRef, staffId, field, payloadToUpdate
-    );
+  static async updateStaffInfo(tenantRef, staffId, payload) {
+    const queryOptions = { where: { tenantRef, staffId }, returning: true };
     const [updated] = await Staff.update(payload, queryOptions);
     return !!updated;
   }


### PR DESCRIPTION
#### What does this PR do?
Tracks the change of staff initial unencrypted password as a way to ensure it's change to a more secure password.

#### Description of Tasks
- add a column on staff model to watch the change of staff's initial password
- update column when the unencrypted password has been changed.

#### Pivotal tracker stories
#165385048